### PR TITLE
Reconstructed missing file

### DIFF
--- a/lib_php/scrapeTagAttr.php
+++ b/lib_php/scrapeTagAttr.php
@@ -1,0 +1,30 @@
+<?php
+    //Collect the input.
+    $input = $_REQUEST["tagPass"];  
+    $inputSplit = explode(" ", $input); 
+    
+    //Collect the url.
+    $url = $inputSplit[0];
+    
+    //Collect the id.
+    $tagName = $inputSplit[1];
+    
+    //Collect the index.
+    $index = $inputSplit[2];
+    
+    //Scrape the data.
+    $content = file_get_contents($url);
+    $dom = new DOMDocument;
+    @$dom->loadHTML($content);
+    $scrapedContent = $dom->getElementsByTagName($tagName);
+    $collectedContent = "";
+    $i = 0;
+
+    foreach ($scrapedContent as $currentContent) {
+        $node = $scrapedContent->item($i);
+        $collectedContent .= $node->nodeValue . ",";
+        $i++;
+    }
+
+    echo $collectedContent;
+?>


### PR DESCRIPTION
I reconstructed ```scrapeTagAttr.php``` based on the other files in ```lib_php```. It does not yet work when you use URLs with GET-parameters in it, but the other files don't do that as well. I am working on a fix for that. In the meantime, you can open an issue for that.